### PR TITLE
Removed use of plagiarism_update_status per MDL-71326 and MDL-71175

### DIFF
--- a/report/grading/report.php
+++ b/report/grading/report.php
@@ -409,10 +409,6 @@ class quizanon_grading_report extends quiz_grading_report {
             $select->class = 'mb-3 mt-1';
             echo $OUTPUT->render($select);
         }
-        if (!empty($CFG->enableplagiarism)) {
-            require_once($CFG->libdir . '/plagiarismlib.php');
-            echo plagiarism_update_status($course, $cm);
-        }
     }
 
     /**

--- a/report/overview/report.php
+++ b/report/overview/report.php
@@ -291,10 +291,6 @@ class quizanon_overview_report extends quiz_overview_report {
             $select->class = 'mb-3 mt-1';
             echo $OUTPUT->render($select);
         }
-        if (!empty($CFG->enableplagiarism)) {
-            require_once($CFG->libdir . '/plagiarismlib.php');
-            echo plagiarism_update_status($course, $cm);
-        }
     }
 
     /**

--- a/report/responses/report.php
+++ b/report/responses/report.php
@@ -258,10 +258,6 @@ class quizanon_responses_report extends quiz_responses_report {
             $select->class = 'mb-3 mt-1';
             echo $OUTPUT->render($select);
         }
-        if (!empty($CFG->enableplagiarism)) {
-            require_once($CFG->libdir . '/plagiarismlib.php');
-            echo plagiarism_update_status($course, $cm);
-        }
     }
 
     /**

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025040100; // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025040101; // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2024100700; // Requires this Moodle version.
 $plugin->component = 'local_quizanon'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
My [reading of the deprecated function](https://github.com/moodle/moodle/blob/MOODLE_404_STABLE/lib/plagiarismlib.php#L85)  is that the functionality is removed from the plagiarismlib (in M4.5) and should be implemented by respective plagiarism plugins. Please verify in review.

See also:
- [MDL-71326](https://tracker.moodle.org/browse/MDL-71326)
- [MDL-71175](https://tracker.moodle.org/browse/MDL-71175)